### PR TITLE
Reduce memory usage by extracting constants and replacing drawable-based accuracy bars

### DIFF
--- a/resources-round-240x240/drawables.xml
+++ b/resources-round-240x240/drawables.xml
@@ -1,18 +1,6 @@
 <!-- -*- mode:xml; tab-width:2; c-basic-offset:2; intent-tabs-mode:nil; -*- ex: set tabstop=2 expandtab: -->
 <drawables>
   <bitmap id="AppIcon" filename="../resources/drawables/launcher-40x40.png" />
-  <drawable-list id="drawHeaderAccuracy1" x="109" y="17" width="4" height="8" >
-    <shape type="rectangle" x="0" y="0" width="fill" height="fill" />
-  </drawable-list>
-  <drawable-list id="drawHeaderAccuracy2" x="115" y="13" width="4" height="12" >
-    <shape type="rectangle" x="0" y="0" width="fill" height="fill" />
-  </drawable-list>
-  <drawable-list id="drawHeaderAccuracy3" x="121" y="9" width="4" height="16" >
-    <shape type="rectangle" x="0" y="0" width="fill" height="fill" />
-  </drawable-list>
-  <drawable-list id="drawHeaderAccuracy4" x="127" y="5" width="4" height="20" >
-    <shape type="rectangle" x="0" y="0" width="fill" height="fill" />
-  </drawable-list>
   <drawable-list id="drawContentBorders" x="0" y="29" width="fill" height="182" >
     <shape type="rectangle" x="0" y="0" width="fill" height="2" color="Gfx.COLOR_LT_GRAY" />
     <shape type="rectangle" x="0" y="180" width="fill" height="2" color="Gfx.COLOR_LT_GRAY" />

--- a/resources-round-260x260/drawables.xml
+++ b/resources-round-260x260/drawables.xml
@@ -1,18 +1,6 @@
 <!-- -*- mode:xml; tab-width:2; c-basic-offset:2; intent-tabs-mode:nil; -*- ex: set tabstop=2 expandtab: -->
 <drawables>
   <bitmap id="AppIcon" filename="../resources/drawables/launcher-40x40.png" />
-  <drawable-list id="drawHeaderAccuracy1" x="119" y="19" width="4" height="8" >
-    <shape type="rectangle" x="0" y="0" width="fill" height="fill" />
-  </drawable-list>
-  <drawable-list id="drawHeaderAccuracy2" x="125" y="15" width="4" height="12" >
-    <shape type="rectangle" x="0" y="0" width="fill" height="fill" />
-  </drawable-list>
-  <drawable-list id="drawHeaderAccuracy3" x="131" y="11" width="4" height="16" >
-    <shape type="rectangle" x="0" y="0" width="fill" height="fill" />
-  </drawable-list>
-  <drawable-list id="drawHeaderAccuracy4" x="137" y="7" width="4" height="20" >
-    <shape type="rectangle" x="0" y="0" width="fill" height="fill" />
-  </drawable-list>
   <drawable-list id="drawContentBorders" x="0" y="32" width="fill" height="197" >
     <shape type="rectangle" x="0" y="0" width="fill" height="2" color="Gfx.COLOR_LT_GRAY" />
     <shape type="rectangle" x="0" y="195" width="fill" height="2" color="Gfx.COLOR_LT_GRAY" />

--- a/resources-round-280x280/drawables.xml
+++ b/resources-round-280x280/drawables.xml
@@ -1,18 +1,6 @@
 <!-- -*- mode:xml; tab-width:2; c-basic-offset:2; intent-tabs-mode:nil; -*- ex: set tabstop=2 expandtab: -->
 <drawables>
   <bitmap id="AppIcon" filename="../resources/drawables/launcher-40x40.png" />
-  <drawable-list id="drawHeaderAccuracy1" x="129" y="20" width="4" height="8" >
-    <shape type="rectangle" x="0" y="0" width="fill" height="fill" />
-  </drawable-list>
-  <drawable-list id="drawHeaderAccuracy2" x="135" y="16" width="4" height="12" >
-    <shape type="rectangle" x="0" y="0" width="fill" height="fill" />
-  </drawable-list>
-  <drawable-list id="drawHeaderAccuracy3" x="141" y="12" width="4" height="16" >
-    <shape type="rectangle" x="0" y="0" width="fill" height="fill" />
-  </drawable-list>
-  <drawable-list id="drawHeaderAccuracy4" x="147" y="8" width="4" height="20" >
-    <shape type="rectangle" x="0" y="0" width="fill" height="fill" />
-  </drawable-list>
   <drawable-list id="drawContentBorders" x="0" y="34" width="fill" height="212" >
     <shape type="rectangle" x="0" y="0" width="fill" height="2" color="Gfx.COLOR_LT_GRAY" />
     <shape type="rectangle" x="0" y="210" width="fill" height="2" color="Gfx.COLOR_LT_GRAY" />

--- a/resources-vivoactive3/drawables.xml
+++ b/resources-vivoactive3/drawables.xml
@@ -1,18 +1,6 @@
 <!-- -*- mode:xml; tab-width:2; c-basic-offset:2; intent-tabs-mode:nil; -*- ex: set tabstop=2 expandtab: -->
 <drawables>
   <bitmap id="AppIcon" filename="../resources/drawables/launcher-40x33.png" />
-  <drawable-list id="drawHeaderAccuracy1" x="109" y="17" width="4" height="8" >
-    <shape type="rectangle" x="0" y="0" width="fill" height="fill" />
-  </drawable-list>
-  <drawable-list id="drawHeaderAccuracy2" x="115" y="13" width="4" height="12" >
-    <shape type="rectangle" x="0" y="0" width="fill" height="fill" />
-  </drawable-list>
-  <drawable-list id="drawHeaderAccuracy3" x="121" y="9" width="4" height="16" >
-    <shape type="rectangle" x="0" y="0" width="fill" height="fill" />
-  </drawable-list>
-  <drawable-list id="drawHeaderAccuracy4" x="127" y="5" width="4" height="20" >
-    <shape type="rectangle" x="0" y="0" width="fill" height="fill" />
-  </drawable-list>
   <drawable-list id="drawContentBorders" x="0" y="29" width="fill" height="182" >
     <shape type="rectangle" x="0" y="0" width="fill" height="2" color="Gfx.COLOR_LT_GRAY" />
     <shape type="rectangle" x="0" y="180" width="fill" height="2" color="Gfx.COLOR_LT_GRAY" />

--- a/source/views/MyDrawableHeader.mc
+++ b/source/views/MyDrawableHeader.mc
@@ -44,11 +44,8 @@ class MyDrawableHeader extends Ui.Drawable {
   // VARIABLES
   //
 
-  // Resources
-  private var oRezHeaderAccuracy1 as Ui.Drawable;
-  private var oRezHeaderAccuracy2 as Ui.Drawable;
-  private var oRezHeaderAccuracy3 as Ui.Drawable;
-  private var oRezHeaderAccuracy4 as Ui.Drawable;
+  // Constants
+  private const BAR_HEIGHTS as Array<Number> = [8, 12, 16, 20];
 
   // Background color
   private var iColorBackground as Number = Gfx.COLOR_TRANSPARENT;
@@ -64,67 +61,47 @@ class MyDrawableHeader extends Ui.Drawable {
   function initialize() {
     Drawable.initialize({:identifier => "MyDrawableHeader"});
 
-    // Resources
-    oRezHeaderAccuracy1 = new Rez.Drawables.drawHeaderAccuracy1();
-    oRezHeaderAccuracy2 = new Rez.Drawables.drawHeaderAccuracy2();
-    oRezHeaderAccuracy3 = new Rez.Drawables.drawHeaderAccuracy3();
-    oRezHeaderAccuracy4 = new Rez.Drawables.drawHeaderAccuracy4();
   }
 
   function draw(_oDC) {
-    // Draw
-    // ... background
+    // Draw background
     _oDC.setColor(self.iColorBackground, self.iColorBackground);
     _oDC.clear();
 
-    // ... positioning accuracy
+    // Determine color and number of bars to highlight
+    var iBars = 0;
+    var iColor = Gfx.COLOR_LT_GRAY;
     switch(self.iPositionAccuracy) {
 
-    case Pos.QUALITY_GOOD:
-      _oDC.setColor(Gfx.COLOR_DK_GREEN, Gfx.COLOR_TRANSPARENT);
-      self.oRezHeaderAccuracy1.draw(_oDC);
-      self.oRezHeaderAccuracy2.draw(_oDC);
-      self.oRezHeaderAccuracy3.draw(_oDC);
-      self.oRezHeaderAccuracy4.draw(_oDC);
-      break;
+      case Pos.QUALITY_GOOD:
+        iBars = 4;
+        iColor = Gfx.COLOR_DK_GREEN;
+        break;
 
-    case Pos.QUALITY_USABLE:
-      _oDC.setColor(Gfx.COLOR_ORANGE, Gfx.COLOR_TRANSPARENT);
-      self.oRezHeaderAccuracy1.draw(_oDC);
-      self.oRezHeaderAccuracy2.draw(_oDC);
-      self.oRezHeaderAccuracy3.draw(_oDC);
-      _oDC.setColor(Gfx.COLOR_LT_GRAY, Gfx.COLOR_TRANSPARENT);
-      self.oRezHeaderAccuracy4.draw(_oDC);
-      break;
+      case Pos.QUALITY_USABLE:
+        iBars = 3;
+        iColor = Gfx.COLOR_ORANGE;
+        break;
 
-    case Pos.QUALITY_POOR:
-      _oDC.setColor(Gfx.COLOR_RED, Gfx.COLOR_TRANSPARENT);
-      self.oRezHeaderAccuracy1.draw(_oDC);
-      self.oRezHeaderAccuracy2.draw(_oDC);
-      _oDC.setColor(Gfx.COLOR_LT_GRAY, Gfx.COLOR_TRANSPARENT);
-      self.oRezHeaderAccuracy3.draw(_oDC);
-      self.oRezHeaderAccuracy4.draw(_oDC);
-      break;
+      case Pos.QUALITY_POOR:
+        iBars = 2;
+        iColor = Gfx.COLOR_RED;
+        break;
 
-    case Pos.QUALITY_LAST_KNOWN:
-      _oDC.setColor(Gfx.COLOR_DK_RED, Gfx.COLOR_TRANSPARENT);
-      self.oRezHeaderAccuracy1.draw(_oDC);
-      _oDC.setColor(Gfx.COLOR_LT_GRAY, Gfx.COLOR_TRANSPARENT);
-      self.oRezHeaderAccuracy2.draw(_oDC);
-      self.oRezHeaderAccuracy3.draw(_oDC);
-      self.oRezHeaderAccuracy4.draw(_oDC);
-      break;
+      case Pos.QUALITY_LAST_KNOWN:
+        iBars = 1;
+        iColor = Gfx.COLOR_DK_RED;
+        break;
 
-    case Pos.QUALITY_NOT_AVAILABLE:
-    default:
-      _oDC.setColor(Gfx.COLOR_LT_GRAY, Gfx.COLOR_TRANSPARENT);
-      self.oRezHeaderAccuracy1.draw(_oDC);
-      self.oRezHeaderAccuracy2.draw(_oDC);
-      self.oRezHeaderAccuracy3.draw(_oDC);
-      self.oRezHeaderAccuracy4.draw(_oDC);
-      break;
-
+      case Pos.QUALITY_NOT_AVAILABLE:
+      default:
+        iBars = 0;
+        break;
     }
+
+    // Geometry
+    self.drawAccuracyBars(_oDC, iBars, iColor);
+
   }
 
 
@@ -138,6 +115,27 @@ class MyDrawableHeader extends Ui.Drawable {
 
   function setPositionAccuracy(_iPositionAccuracy as Number) as Void {
     self.iPositionAccuracy = _iPositionAccuracy;
+  }
+
+  //
+  // FUNCTIONS: private
+  //
+
+  private function drawAccuracyBars(_dc as Gfx.Dc, _iBars as Number, _iColor as Number) as Void {
+    var w = _dc.getWidth();
+    var h = _dc.getHeight();
+
+    var baseX = (0.5f * w).toNumber() - 11; // Left bar
+    var baseline = (0.1f * h + 1).toNumber(); // Bottom anchor
+
+    for (var i = 0; i < BAR_HEIGHTS.size(); i++) {
+      if (i < _iBars) {
+        _dc.setColor(_iColor, Gfx.COLOR_TRANSPARENT);
+      } else {
+        _dc.setColor(Gfx.COLOR_LT_GRAY, Gfx.COLOR_TRANSPARENT);
+      }
+      _dc.fillRectangle(baseX + i * 6, baseline - self.BAR_HEIGHTS[i], 4, self.BAR_HEIGHTS[i]);
+    }
   }
 
 }

--- a/source/views/MyViewVarioplot.mc
+++ b/source/views/MyViewVarioplot.mc
@@ -48,6 +48,9 @@ class MyViewVarioplot extends MyViewHeader {
 
   //CONSTANTS
   public const TIME_CONSTANT = 4;
+  private const AISCALE_RANGE_0 as Array<Number> = [-3000, -2000, -1000, -50, 50, 1000, 2000, 3000];
+  private const AISCALE_RANGE_1 as Array<Number> = [-6000, -4000, -2000, -100, 100, 2000, 4000, 6000];
+  private const AISCALE_RANGE_2 as Array<Number> = [-9000, -6000, -3000, -150, 150, 3000, 6000, 9000];
 
   //
   // VARIABLES
@@ -68,7 +71,7 @@ class MyViewVarioplot extends MyViewHeader {
   private var iDotRadius as Number = 5;
 
   // Color scale
-  private var aiScale as Array<Number> = [-3000, -2000, -1000, -50, 50, 1000, 2000, 3000] as Array<Number>;
+  private var aiScale as Array<Number> = AISCALE_RANGE_0;
 
 
   //
@@ -136,16 +139,16 @@ class MyViewVarioplot extends MyViewHeader {
 
     // Color scale
     switch($.oMySettings.iVariometerRange) {
-    default:
-    case 0:
-      self.aiScale = [-3000, -2000, -1000, -50, 50, 1000, 2000, 3000] as Array<Number>;
-      break;
-    case 1:
-      self.aiScale = [-6000, -4000, -2000, -100, 100, 2000, 4000, 6000] as Array<Number>;
-      break;
-    case 2:
-      self.aiScale = [-9000, -6000, -3000, -150, 150, 3000, 6000, 9000] as Array<Number>;
-      break;
+      default:
+      case 0:
+        self.aiScale = AISCALE_RANGE_0;
+        break;
+      case 1:
+        self.aiScale = AISCALE_RANGE_1;
+        break;
+      case 2:
+        self.aiScale = AISCALE_RANGE_2;
+        break;
     }
 
     // Unmute tones


### PR DESCRIPTION
This pull request refactors the variometer view and header to reduce memory usage and simplify rendering.

### Changes
**Variometer Scale:**
- Extracted repeated aiScale range arrays into private constants (AISCALE_RANGE_0/1/2).
- Eliminates repeated allocations in prepare(), reducing garbage collection pressure.

**Accuracy Bars:**
- Removed drawable-based GPS accuracy bar resources from all layouts.
- Added drawAccuracyBars() to render bars dynamically based on iPositionAccuracy.
- Simplified color/visibility logic with BAR_HEIGHTS constant.

### Impact
These changes reduce resource and runtime memory usage (~1.8 kB), and preserve existing behavior and appearance.